### PR TITLE
feat: add multi-chain deploy wrapper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,23 @@
 # DEPLOYMENT PRIVATE KEY
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
-# NETWORKS
+# SHARED SETTINGS FOR .env
 LOCALHOST_RPC_URL=http://127.0.0.1:8545
-
-# CHAIN ID
-CHAIN_ID=31337
-
-# ACTIVATE BLOBS is set to True when the contracts that will be deployed
-# are going to check and verify blobs on-chain. Set it to False if blob
-# verification should be skipped.
-ACTIVATE_BLOBS=True
-
+DEPLOY_CHAINS=base,sepolia
+ETHERSCAN_API_KEY=your_explorer_key
 # Verification mode for deploy_all.sh: auto | true | false
 # auto disables verification on local chain IDs (31337/1337), enables elsewhere.
 VERIFY_MODE=auto
+
+# Per-chain template for .env.<chain>
+CHAIN_ID=31337
+RPC_URL=http://127.0.0.1:8545
+
+# Set to True when deployed contracts should verify blobs on-chain.
+ACTIVATE_BLOBS=True
+
+# Optional explorer override for chains that need a custom verifier endpoint.
+ETHERSCAN_API_URL=
 
 # Optional pre-deployed library addresses (if unset or stale, deploy_all.sh auto-deploys and prints exports)
 POSEIDON_T3_ADDRESS=

--- a/README.md
+++ b/README.md
@@ -164,14 +164,23 @@ forge script script/DeployAll.s.sol --rpc-url http://localhost:8545 --broadcast
 
 ### Testnet/Mainnet Deployment
 
-1. Configure network in `.env`:
+1. Configure shared values in `.env` and chain-specific values in `.env.<chain>`.
+
+Shared `.env`:
 
 ```bash
 PRIVATE_KEY=your_deployment_key
+ETHERSCAN_API_KEY=your_explorer_key
+VERIFY_MODE=auto
+DEPLOY_CHAINS=base,sepolia
+```
+
+Chain file, for example `.env.base`:
+
+```bash
 RPC_URL=your_rpc_endpoint
 CHAIN_ID=your_chain_id
 ACTIVATE_BLOBS=True
-VERIFY_MODE=auto
 
 # Optional: reuse already deployed libraries.
 # If any of these are unset or point to an address without bytecode,
@@ -188,6 +197,55 @@ BLOBS_LIB_ADDRESS=
 ```bash
 ./deploy_all.sh
 ```
+
+`deploy_all.sh` loads `.env` first and then uses the currently exported
+single-chain variables. For direct single-chain use, source one chain file into
+your shell first or export the variables manually.
+
+### Multi-Chain Deployment
+
+Use a shared `.env` plus one per-chain file for each target network.
+
+Shared `.env`:
+
+```bash
+PRIVATE_KEY=your_deployment_key
+LOCALHOST_RPC_URL=http://127.0.0.1:8545
+ETHERSCAN_API_KEY=your_explorer_key
+VERIFY_MODE=auto
+DEPLOY_CHAINS=base,sepolia,arbitrum
+```
+
+Per-chain `.env.<chain>` files, for example `.env.base`:
+
+```bash
+CHAIN_ID=8453
+RPC_URL=https://your-base-rpc
+ACTIVATE_BLOBS=False
+
+# Optional per-chain overrides
+ETHERSCAN_API_URL=
+POSEIDON_T3_ADDRESS=
+POSEIDON_T4_ADDRESS=
+STATE_ROOT_LIB_ADDRESS=
+PROCESS_ID_LIB_ADDRESS=
+BLOBS_LIB_ADDRESS=
+```
+
+Then run:
+
+```bash
+./deploy_all_contracts_to_all_chains.sh
+```
+
+The wrapper:
+1. Loads shared values from `.env`
+2. Clears chain-scoped deployment variables
+3. Loads `.env.<chain>` for each chain listed in `DEPLOY_CHAINS`
+4. Falls back to `.env-<chain>` if the dotted filename does not exist
+5. Calls `./deploy_all.sh` once per chain
+
+This means old single-chain values left in `.env` will not bleed into multi-chain runs.
 
 `deploy_all.sh` resolves libraries in this order:
 1. `PoseidonT3`

--- a/deploy_all_contracts_to_all_chains.sh
+++ b/deploy_all_contracts_to_all_chains.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
+log_info() { echo "[deploy_all_all_chains] $*"; }
+log_warn() { echo "[deploy_all_all_chains] Warning: $*" >&2; }
+log_error() { echo "[deploy_all_all_chains] Error: $*" >&2; }
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        log_error "$cmd is required but not installed."
+        exit 1
+    fi
+}
+
+require_cmd bash
+
+SHARED_ENV_FILE="${SHARED_ENV_FILE:-$SCRIPT_DIR/.env}"
+CHAIN_ENV_DIR="${CHAIN_ENV_DIR:-$SCRIPT_DIR}"
+DEPLOY_SINGLE_CHAIN_CMD="${DEPLOY_SINGLE_CHAIN_CMD:-$SCRIPT_DIR/deploy_all.sh}"
+
+if [ ! -f "$SHARED_ENV_FILE" ]; then
+    log_error "Shared env file not found: $SHARED_ENV_FILE"
+    exit 1
+fi
+
+if [ ! -x "$DEPLOY_SINGLE_CHAIN_CMD" ]; then
+    log_error "Single-chain deploy command is not executable: $DEPLOY_SINGLE_CHAIN_CMD"
+    exit 1
+fi
+
+chain_env_file_for() {
+    local chain="$1"
+    local dot_file="$CHAIN_ENV_DIR/.env.$chain"
+    local dash_file="$CHAIN_ENV_DIR/.env-$chain"
+
+    if [ -f "$dot_file" ]; then
+        echo "$dot_file"
+        return 0
+    fi
+
+    if [ -f "$dash_file" ]; then
+        echo "$dash_file"
+        return 0
+    fi
+
+    return 1
+}
+
+unset_chain_specific_vars() {
+    unset CHAIN_ID || true
+    unset RPC_URL || true
+    unset ACTIVATE_BLOBS || true
+    unset ETHERSCAN_API_URL || true
+    unset POSEIDON_T3_ADDRESS || true
+    unset POSEIDON_T4_ADDRESS || true
+    unset STATE_ROOT_LIB_ADDRESS || true
+    unset PROCESS_ID_LIB_ADDRESS || true
+    unset BLOBS_LIB_ADDRESS || true
+}
+
+source_env_file() {
+    local env_file="$1"
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+}
+
+load_chain_env() {
+    local chain="$1"
+    local chain_env_file=""
+
+    source_env_file "$SHARED_ENV_FILE"
+    unset_chain_specific_vars
+
+    if ! chain_env_file=$(chain_env_file_for "$chain"); then
+        log_error "No env file found for chain '$chain'. Expected $CHAIN_ENV_DIR/.env.$chain or $CHAIN_ENV_DIR/.env-$chain"
+        exit 1
+    fi
+
+    source_env_file "$chain_env_file"
+}
+
+validate_loaded_env() {
+    : "${PRIVATE_KEY:?PRIVATE_KEY is not set after loading env files}"
+    : "${CHAIN_ID:?CHAIN_ID is not set after loading env files}"
+    : "${RPC_URL:?RPC_URL is not set after loading env files}"
+}
+
+parse_deploy_chains() {
+    local raw="${DEPLOY_CHAINS:-}"
+    local normalized=""
+
+    if [ -z "$raw" ]; then
+        log_error "DEPLOY_CHAINS is not set in $SHARED_ENV_FILE"
+        exit 1
+    fi
+
+    normalized="${raw//,/ }"
+    read -r -a DEPLOY_CHAIN_LIST <<< "$normalized"
+
+    if [ "${#DEPLOY_CHAIN_LIST[@]}" -eq 0 ]; then
+        log_error "DEPLOY_CHAINS is empty in $SHARED_ENV_FILE"
+        exit 1
+    fi
+}
+
+source_env_file "$SHARED_ENV_FILE"
+parse_deploy_chains
+
+for chain in "${DEPLOY_CHAIN_LIST[@]}"; do
+    log_info "Preparing deployment for chain '$chain'"
+    load_chain_env "$chain"
+    validate_loaded_env
+    log_info "Deploying to chain '$chain' (CHAIN_ID=$CHAIN_ID, RPC_URL=$RPC_URL)"
+    "$DEPLOY_SINGLE_CHAIN_CMD"
+done
+
+log_info "Finished deployments for: ${DEPLOY_CHAIN_LIST[*]}"


### PR DESCRIPTION
Add deploy_all_contracts_to_all_chains.sh to load shared .env
and per-chain .env.<chain> files, then call the existing
single-chain deploy script for each configured target.

Document the shared and per-chain env layout in README.md
and .env.example so the multi-chain workflow is explicit.
